### PR TITLE
[Bug]: Sub-windows are empty and return an error in console

### DIFF
--- a/dependencies.py
+++ b/dependencies.py
@@ -2,7 +2,38 @@ import importlib.util
 import subprocess
 import sys
 import os
-from PIL import Image
+from PIL import Image, ImageTk # Added ImageTk
+
+
+global_icon_pil_image = None # Only global PIL Image
+
+
+def get_global_icon_photo_if_available():
+    if global_icon_pil_image is not None:
+        try:
+            # Always create a new PhotoImage instance
+            return ImageTk.PhotoImage(global_icon_pil_image)
+        except RuntimeError as e:
+            print(f"DEBUG: Could not create PhotoImage (Tkinter root not yet available): {e}")
+            return None # Ensure it's None if creation fails
+        except Exception as e:
+            print(f"Error creating PhotoImage: {e}")
+            return None
+    return None
+
+
+def load_global_icon_pil():
+    global global_icon_pil_image
+    icon_path = resource_path("assets/potato.png")
+    if os.path.exists(icon_path):
+        global_icon_pil_image = Image.open(icon_path)
+        # Also generate .ico from .png here for consistency
+        ico_path = resource_path("assets/potato.ico")
+        if not os.path.exists(ico_path):
+            global_icon_pil_image.save(ico_path, format='ICO', sizes=[(256, 256)])
+            print(f"Generated {ico_path} from {icon_path}")
+    else:
+        print(f"Warning: Icon file not found at {icon_path}. Application may not display icon.")
 
 
 def resource_path(relative_path):

--- a/gui.py
+++ b/gui.py
@@ -18,10 +18,11 @@ def lose_screen():
         root.destroy()
     
     root = ctk.CTk()
-    icon_path = dependencies.resource_path("assets/potato.png")
-    icon_image = Image.open(icon_path)
-    root.icon_photo = ImageTk.PhotoImage(icon_image)
-    root.iconphoto(True, root.icon_photo)
+    # Use the globally loaded icon
+    icon_photo = dependencies.get_global_icon_photo_if_available()
+    if icon_photo:
+        root._icon_photo_ref = icon_photo # Keep a strong reference
+        root.iconphoto(True, icon_photo)
     loselabel = ctk.CTkLabel(root, text="You lost!", font=(dependencies.resource_path("assets/font.ttf"), 24))
     loselabel.pack()
     root.title("skakavi krompir")
@@ -36,7 +37,6 @@ def lose_screen():
         return "exit"
     elif returncode == "restart":
         return "restart"
-
 
 
 
@@ -55,10 +55,11 @@ def pause_screen():
     def scores():
         scs.start()
     root = ctk.CTk()
-    icon_path = dependencies.resource_path("assets/potato.png")
-    icon_image = Image.open(icon_path)
-    root.icon_photo = ImageTk.PhotoImage(icon_image)
-    root.iconphoto(True, root.icon_photo)
+    # Use the globally loaded icon
+    icon_photo = dependencies.get_global_icon_photo_if_available()
+    if icon_photo:
+        root._icon_photo_ref = icon_photo # Keep a strong reference
+        root.iconphoto(True, icon_photo)
     pauselabel = ctk.CTkLabel(root, text="Paused", font=(dependencies.resource_path("assets/font.ttf"), 24))
     pauselabel.pack()
     root.title("skakavi krompir")

--- a/options.py
+++ b/options.py
@@ -6,7 +6,7 @@ import dependencies
 import os
 
 
-def start():
+def options():
     def getSettings(key):
         settings = {}
         settings_path = os.path.join(dependencies.get_user_data_dir(), "settings.txt")
@@ -56,18 +56,19 @@ def start():
         
         if file_path:
             shutil.copyfile(file_path, dependencies.resource_path("assets/potato.png"))
-            img = Image.open(dependencies.resource_path("assets/potato.png"))
-            img.save(dependencies.resource_path("assets/potato.ico"), format='ICO', sizes=[(64, 64)])
-            img.resize((64, 64), Image.NEAREST)
-            img.save(dependencies.resource_path("assets/potato.png"), format="PNG")
+            with Image.open(dependencies.resource_path("assets/potato.png")) as img:
+                img.save(dependencies.resource_path("assets/potato.ico"), format='ICO', sizes=[(64, 64)])
+                img.resize((64, 64), Image.NEAREST)
+                img.save(dependencies.resource_path("assets/potato.png"), format="PNG")
             
 
 
     root = ctk.CTk()
-    icon_path = dependencies.resource_path("assets/potato.png")
-    icon_image = Image.open(icon_path)
-    root.icon_photo = ImageTk.PhotoImage(icon_image)
-    root.iconphoto(True, root.icon_photo)
+    # Use the globally loaded icon
+    icon_photo = dependencies.get_global_icon_photo_if_available()
+    if icon_photo:
+        root._icon_photo_ref = icon_photo # Keep a strong reference
+        root.iconphoto(True, icon_photo)
     settingsLabel = ctk.CTkLabel(root, text="Settings", font=(dependencies.resource_path("assets/font.ttf"), 24))
     settingsLabel.pack()
     uploadFontButton = ctk.CTkButton(root, text="Upload Font", command=upload_font, font=(dependencies.resource_path("assets/font.ttf"), 12))
@@ -113,3 +114,6 @@ def start():
     root.title("skakavi krompir settings")
     root.geometry("400x400")
     root.mainloop()
+
+def start():
+    options()

--- a/scores.py
+++ b/scores.py
@@ -22,10 +22,11 @@ def start():
                 pass
 
     root = ctk.CTk()
-    icon_path = dependencies.resource_path("assets/potato.png")
-    icon_image = Image.open(icon_path)
-    root.icon_photo = ImageTk.PhotoImage(icon_image)
-    root.iconphoto(True, root.icon_photo)
+    # Use the globally loaded icon
+    icon_photo = dependencies.get_global_icon_photo_if_available()
+    if icon_photo:
+        root._icon_photo_ref = icon_photo # Keep a strong reference
+        root.iconphoto(True, icon_photo)
     root.title("Scores")
     root.geometry("500x500")
 


### PR DESCRIPTION
Fixes #3

Refactor icon handling to use globally loaded icon across GUI components and improve error handling in dependencies